### PR TITLE
FOGL-5945 link updated to get advantech linux 4.0.3.0_64bit driver

### DIFF
--- a/requirements.sh
+++ b/requirements.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ##--------------------------------------------------------------------
-## Copyright (c) 2019 Dianomic Systems
+## Copyright (c) 2019 Dianomic Systems Inc.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ mkdir -p ${DIR}
 cd ${DIR}
 echo Downloading Advantech library...
 # From version 4.0.3.0 the downloaded file is not a zip file.
-wget https://downloadt.advantech.com/download/downloadsr.aspx?File_Id=1-21MC6UN -O linux_driver_source_${driver_version}.run
+wget https://driver-libs.s3.amazonaws.com/advantech/linux_driver_source_${driver_version}.run
 # sudo apt install -y unzip
 # echo Unzipping driver source...
 # unzip linux_driver_source_${driver_version}.run.zip


### PR DESCRIPTION
Signed-off-by: ashish-jabble <ashish@dianomic.com>

Custom Packages are available at http://archives.fledge-iot.org/fixes/FOGL-5945/

Package contents will be like as follows
```
$ sudo dpkg -c fledge-south-usb4704-1.9.1-x86_64.deb 
drwxrwxr-x ubuntu/ubuntu     0 2021-09-23 11:43 ./
drwxrwxr-x ubuntu/ubuntu     0 2021-09-23 11:43 ./opt/
drwxrwxr-x ubuntu/ubuntu     0 2021-09-23 11:43 ./opt/advantech/
drwxrwxr-x ubuntu/ubuntu     0 2021-09-23 11:43 ./opt/advantech/libs/
-rwxr-xr-x ubuntu/ubuntu 1662050 2021-09-23 11:43 ./opt/advantech/libs/libbiodaq.so
-rwxr-xr-x ubuntu/ubuntu 1112597 2021-09-23 11:43 ./opt/advantech/libs/libbiodaqutil.so
drwxrwxr-x ubuntu/ubuntu       0 2021-09-23 11:43 ./usr/
drwxrwxr-x ubuntu/ubuntu       0 2021-09-23 11:43 ./usr/lib/
drwxrwxr-x ubuntu/ubuntu       0 2021-09-23 11:43 ./usr/local/
drwxrwxr-x ubuntu/ubuntu       0 2021-09-23 11:43 ./usr/local/fledge/
drwxrwxr-x ubuntu/ubuntu       0 2021-09-23 11:43 ./usr/local/fledge/plugins/
drwxrwxr-x ubuntu/ubuntu       0 2021-09-23 11:43 ./usr/local/fledge/plugins/south/
drwxrwxr-x ubuntu/ubuntu       0 2021-09-23 11:43 ./usr/local/fledge/plugins/south/usb4704/
-rwxrwxr-x ubuntu/ubuntu   87544 2021-09-23 11:43 ./usr/local/fledge/plugins/south/usb4704/libusb4704.so.1
lrwxrwxrwx ubuntu/ubuntu       0 2021-09-23 11:43 ./usr/lib/libbiodaq.so -> /opt/advantech/libs/libbiodaq.so
lrwxrwxrwx ubuntu/ubuntu       0 2021-09-23 11:43 ./usr/lib/libbiodaqutil.so -> /opt/advantech/libs/libbiodaqutil.so
lrwxrwxrwx ubuntu/ubuntu       0 2021-09-23 11:43 ./usr/local/fledge/plugins/south/usb4704/libusb4704.so -> libusb4704.so.1
```